### PR TITLE
README: Specify that this tracker is for Container Linux bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# CoreOS Bugs
+# CoreOS Container Linux Bugs
 
-CoreOS has a large number of components. File issues here if you don't know the
-source of the problem.
+Container Linux has a large number of components.
+File issues here if you don't know the source of the problem.

--- a/README.md
+++ b/README.md
@@ -2,3 +2,8 @@
 
 Container Linux has a large number of components.
 File issues here if you don't know the source of the problem.
+
+## Fedora CoreOS
+
+File Fedora CoreOS issues in the
+[Fedora CoreOS issue tracker](https://github.com/coreos/fedora-coreos-tracker/issues).


### PR DESCRIPTION
It's not really being used for other CoreOS Inc. projects anymore.  Discourage the filing of FCOS and RHCOS bugs here.